### PR TITLE
fix: format shop overlay price values

### DIFF
--- a/src/main/java/com/shopprices/Shop.java
+++ b/src/main/java/com/shopprices/Shop.java
@@ -1,6 +1,7 @@
 package com.shopprices;
 
 import net.runelite.api.ItemComposition;
+import net.runelite.client.util.QuantityFormatter;
 
 import java.text.DecimalFormat;
 import java.util.Map;
@@ -29,6 +30,17 @@ public final class Shop {
      */
     public static String formatShopName(String shopName) {
         return String.join("_", shopName.replaceAll(SHOP_KEY_PATTERN, "").toUpperCase().split(" "));
+    }
+
+    /**
+     * Gets RuneScape's precise decimal currency stack value.
+     *
+     * @param priceValue Items sell price value.
+     * @see QuantityFormatter#quantityToRSDecimalStack(int, boolean)
+     *
+     */
+    public static String getPriceValue(int priceValue) {
+        return QuantityFormatter.quantityToRSDecimalStack(priceValue, true) + " gp";
     }
 
     /**

--- a/src/main/java/com/shopprices/ShopPricesOverlay.java
+++ b/src/main/java/com/shopprices/ShopPricesOverlay.java
@@ -89,7 +89,7 @@ public class ShopPricesOverlay extends Overlay {
         int sellPrice = activeShop.getSellPrice(itemComposition, currentStock);
 
         int multiplierThreshold = plugin.getConfig().priceThreshold();
-        String sellValue = Shop.getExactPriceValue(sellPrice);
+        String sellValue = Shop.getPriceValue(sellPrice);
         Rectangle bounds = itemWidget.getBounds();
 
 


### PR DESCRIPTION
close #1

Prices now get shortened when greater than or equal to 10,000.

<img width="483" height="295" alt="image" src="https://github.com/user-attachments/assets/049d48ed-164d-4119-b11a-e69b3b6bfd0e" />