### PR TITLE
feat: extend `Shops.ITEMS` interface scroll height

### DIFF
--- a/src/main/java/com/shopprices/ShopPricesPlugin.java
+++ b/src/main/java/com/shopprices/ShopPricesPlugin.java
@@ -91,11 +91,7 @@ public class ShopPricesPlugin extends Plugin {
     protected void onScriptPreFired(ScriptPreFired event) {
         Widget items = client.getWidget(InterfaceID.Shopmain.ITEMS);
 
-        if (items == null) {
-            return;
-        }
-
-        if (event.getScriptId() != ScriptID.UPDATE_SCROLLBAR) {
+        if (items == null || event.getScriptId() != ScriptID.UPDATE_SCROLLBAR) {
             return;
         }
 


### PR DESCRIPTION
Added more space for fitting item price values.

Before:
<img width="505" height="311" alt="image" src="https://github.com/user-attachments/assets/9a7fb74f-10a0-457b-8ac0-61e7eedb2d28" />


After:
<img width="507" height="315" alt="image" src="https://github.com/user-attachments/assets/24bcb2c5-9e95-4ec6-936f-056b5decf3d0" />
